### PR TITLE
Removed duplicates in output of command "help"

### DIFF
--- a/CommunityBot/Modules/Misc.cs
+++ b/CommunityBot/Modules/Misc.cs
@@ -1,6 +1,8 @@
 ﻿using CommunityBot.Preconditions;
 using Discord;
 using Discord.Commands;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -35,15 +37,14 @@ namespace CommunityBot.Modules
             foreach (var module in _service.Modules)
             {
                 string description = null;
-                var descriptionBuilder = new StringBuilder();
-                descriptionBuilder.Append(description);
+                var descriptionBuilder = new List<string>();
                 foreach (var cmd in module.Commands)
                 {
                     var result = await cmd.CheckPreconditionsAsync(Context);
-                    if (result.IsSuccess)
-                        descriptionBuilder.Append($"{cmd.Aliases.First()}\n");
+                    if (result.IsSuccess && !descriptionBuilder.Contains(cmd.Aliases.First()))
+                        descriptionBuilder.Add(cmd.Aliases.First());
                 }
-                description = descriptionBuilder.ToString();
+                description = String.Join("\n", descriptionBuilder);
 
                 if (!string.IsNullOrWhiteSpace(description))
                 {


### PR DESCRIPTION
If a command had multiple functions (like "purge") it listed it multiple times in the sent help message.

Fixed by using List<string> instead of StringBuilder and checking if the command name already got added with List.Contains.