### PR TITLE
Merged commands "help" and "command"

### DIFF
--- a/CommunityBot/Modules/Misc.cs
+++ b/CommunityBot/Modules/Misc.cs
@@ -58,10 +58,10 @@ namespace CommunityBot.Modules
             await dmChannel.SendMessageAsync("", false, builder.Build());
         }
 
-        [Command("command")]
+        [Command("help")]
         [Remarks("Shows what a specific command does and what parameters it takes.")]
         [Cooldown(5)]
-        public async Task HelpAsync(string command)
+        public async Task HelpCommand(string command)
         {
             var dmChannel = await Context.User.GetOrCreateDMChannelAsync();
             var result = _service.Search(Context, command);


### PR DESCRIPTION
Renamed command "command" to "help" so now there are two "help" commands differently overloaded.
Using just "command" without parameters still sends a DM but putting in a command name as parameter shows the usage of that command.

I think this is more intuitive to use and reduces the total number of commands.