### PR TITLE
Added Miunies-Rewards for sending messages

### DIFF
--- a/CommunityBot/CommunityBot.csproj
+++ b/CommunityBot/CommunityBot.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Entities\GlobalUserAccount.cs" />
     <Compile Include="Features\GlobalAccounts\GlobalUserAccounts.cs" />
     <Compile Include="Handlers\EmbedHandler.cs" />
+    <Compile Include="Handlers\MessageRewardHandler.cs" />
     <Compile Include="Helpers\ActionResult.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="Modules\Admin.cs" />

--- a/CommunityBot/Constants.cs
+++ b/CommunityBot/Constants.cs
@@ -9,6 +9,17 @@ namespace CommunityBot
     public static class Constants
     {
         public const ulong DailyMuiniesGain = 250;
-        public static readonly string[] DidYouKnows = { "You can fork me on GitHub ;) xoxo <3", "If you don't know what to add, you can add some of my messages. :P", "Wanna see someone's Miunies? Add a mention to your cash command.", "I just love when a programmer PULL requests their code into me.", "Protection? I don't accept code just from anybody, alright?" };
+        public const int MessageRewardCooldown = 30;
+        public const int MessageRewardMinLenght = 20;
+        public static readonly Tuple<int, int> MessagRewardMinMax = Tuple.Create(1, 5);
+        
+        public static readonly string[] DidYouKnows = {
+            "You can fork me on GitHub ;) xoxo <3",
+            "If you don't know what to add, you can add some of my messages. :P",
+            "Wanna see someone's Miunies? Add a mention to your cash command.",
+            "I just love when a programmer PULL requests their code into me.",
+            "Protection? I don't accept code just from anybody, alright?",
+            "You get a couple Miunies for sending messages (with a short cooldown)."
+        };
     }
 }

--- a/CommunityBot/Entities/GlobalUserAccount.cs
+++ b/CommunityBot/Entities/GlobalUserAccount.cs
@@ -13,6 +13,8 @@ namespace CommunityBot.Entities
         public ulong Miunies { get; set; }
 
         public DateTime LastDaily { get; set; } = DateTime.UtcNow.AddDays(-2);
+
+        public DateTime LastMessage { get; set; } = DateTime.UtcNow;
         /* Add more values to store */
     }
 }

--- a/CommunityBot/Handlers/MessageRewardHandler.cs
+++ b/CommunityBot/Handlers/MessageRewardHandler.cs
@@ -1,0 +1,37 @@
+﻿using CommunityBot.Features.GlobalAccounts;
+using Discord.WebSocket;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CommunityBot.Handlers
+{
+    public static class MessageRewardHandler
+    {
+        public async static Task HandleMessageRewards(SocketMessage s)
+        {
+            var msg = s as SocketUserMessage;
+
+            if (msg == null) return;
+            if (msg.Channel == msg.Author.GetOrCreateDMChannelAsync()) return;            
+            if (msg.Author.IsBot) return;
+            
+            var userAcc = GlobalUserAccounts.GetUserAccount(msg.Author.Id);
+            DateTime now = DateTime.UtcNow;
+
+            // Check if message is long enough and if the coolown of the reward is up - if not return
+            if (now < userAcc.LastMessage.AddSeconds(Constants.MessageRewardCooldown) || msg.Content.Length < Constants.MessageRewardMinLenght)
+            { 
+                return; // This Message is not eligible for a reward
+            }
+
+            // Generate a randomized reward in the configured boundries
+            userAcc.Miunies += (ulong) Global.Rng.Next(Constants.MessagRewardMinMax.Item1, Constants.MessagRewardMinMax.Item2 + 1);
+            userAcc.LastMessage = now;
+
+            GlobalUserAccounts.SaveAccounts();
+        }
+    }
+}

--- a/CommunityBot/Program.cs
+++ b/CommunityBot/Program.cs
@@ -30,6 +30,7 @@ namespace CommunityBot
             _client.Log += Logger.Log;
             _client.Ready += Timers.StartTimer;
             _client.ReactionAdded += OnReactionAdded;
+            _client.MessageReceived += MessageRewardHandler.HandleMessageRewards;
             // Subscribe to other events here.
 
             await InitializeCommandHandler();


### PR DESCRIPTION
**WOOOHOO even moooar Economy-Stuff!**
Currently rewards sending a message that is longer than 20 chars with 1-5 Miunies.
This reward has a cooldown of 30 seconds individually for each User.

These values are configurable inside the Constants class.

NOTE:
Not sure if it is the way you like it...
It would be less overhead (and less asynchronious things happening) to just add the function call of `HandleMessageRewards()` inside the `CommandHander.HandleCommandAsync()` and not register it to the `client.OnMessageReceived` Event.
The checks are essencially the same but it is not really about handling a command... so I felt putting it there would just make the code more spaghetti than it needs to be ^^

My biggest worry is that since it is updating (loading, modifying and saving) a userAccount asynchroniously that we could possibly run into race conditions if other commands do that aswell...
Like if it wants to reward a user and loads the account but then gets interrupted by the async scheduler a command continues to get executed and saves something to the account - and we would have an invalid / old userAccount in memory and probably will overwrite the change that the command did to it later on...
I have tested it quite a bit and it never seemed to have happend but being aware of this is probably not bad.
I don't know... maybe you know more than me how to address that or if I am just being overcautious...