### PR TITLE
Theadsafty & One file per UserAccount

### DIFF
--- a/CommunityBot/Configuration/DataStorage.cs
+++ b/CommunityBot/Configuration/DataStorage.cs
@@ -10,7 +10,7 @@ namespace CommunityBot.Configuration
 {
     class DataStorage
     {
-        private static readonly string resourcesFolder = "resources";
+        private static readonly string resourcesFolder = Constants.ResourceFolder;
 
         static DataStorage()
         {

--- a/CommunityBot/Constants.cs
+++ b/CommunityBot/Constants.cs
@@ -8,6 +8,8 @@ namespace CommunityBot
 {
     public static class Constants
     {
+        internal static readonly string ResourceFolder = "resources";
+        internal static readonly string UserAccountsFolder = "users";
         public const ulong DailyMuiniesGain = 250;
         public const int MessageRewardCooldown = 30;
         public const int MessageRewardMinLenght = 20;

--- a/CommunityBot/Features/Economy/Daily.cs
+++ b/CommunityBot/Features/Economy/Daily.cs
@@ -21,7 +21,7 @@ namespace CommunityBot.Features.Economy
 
             account.Miunies += Constants.DailyMuiniesGain;
             account.LastDaily = DateTime.UtcNow;
-            GlobalUserAccounts.SaveAccounts();
+            GlobalUserAccounts.SaveAccounts(userId);
             return DailyResult.Success;
         }
     }

--- a/CommunityBot/Handlers/MessageRewardHandler.cs
+++ b/CommunityBot/Handlers/MessageRewardHandler.cs
@@ -31,7 +31,7 @@ namespace CommunityBot.Handlers
             userAcc.Miunies += (ulong) Global.Rng.Next(Constants.MessagRewardMinMax.Item1, Constants.MessagRewardMinMax.Item2 + 1);
             userAcc.LastMessage = now;
 
-            GlobalUserAccounts.SaveAccounts();
+            GlobalUserAccounts.SaveAccounts(msg.Author.Id);
         }
     }
 }

--- a/CommunityBot/Modules/Economy.cs
+++ b/CommunityBot/Modules/Economy.cs
@@ -64,7 +64,7 @@ namespace CommunityBot.Modules
             var transferTarget = GlobalUserAccounts.GetUserAccount(target.Id);
             transferSource.Miunies -= amount;
             transferTarget.Miunies += amount;
-            GlobalUserAccounts.SaveAccounts();
+            GlobalUserAccounts.SaveAccounts(transferSource.Id, transferTarget.Id);
             await ReplyAsync($" :white_check_mark: {Context.User.Username} has given {target.Username} {amount} Minuies!");
         }
 
@@ -98,7 +98,7 @@ namespace CommunityBot.Modules
             }
 
             account.Miunies -= amount;
-            GlobalUserAccounts.SaveAccounts();
+            GlobalUserAccounts.SaveAccounts(Context.User.Id);
 
             IUserMessage msg = await ReplyAsync(Global.slot.Spin());
             await Task.Delay(1000);
@@ -110,7 +110,7 @@ namespace CommunityBot.Modules
             if (moneyGain > 0)
             {
                 account.Miunies += moneyGain;
-                GlobalUserAccounts.SaveAccounts();
+                GlobalUserAccounts.SaveAccounts(Context.User.Id);
             }
 
             string message = "You played and ";


### PR DESCRIPTION
- Made UserAccounts safe for multiple threads to access change and save.
- Changed GlobalUserAccounts to store accounts in single files inside a folder instead of it being just one big file.
- SaveAccounts() still saves all accounts but also can take any amount of id's and then only saves those
- Added the location of resources and the location where to save useraccounts (which will be a subfolder of resources) to the "Constants" class
- Changed the String.Concats for creating Directories / Files to Path.Combines for eventual crossplatform compatibily