### PR TITLE
Modified Help - Change Game

### DIFF
--- a/CommunityBot/Modules/Admin.cs
+++ b/CommunityBot/Modules/Admin.cs
@@ -149,6 +149,15 @@ namespace CommunityBot.Modules
             await Context.Message.DeleteAsync();
         }
 
+        [Command("Game"), Alias("ChangeGame", "SetGame")]
+        [Remarks("Change what the bot is currently playing.")]
+        [RequireOwner]
+        public async Task SetGame([Remainder] string gamename)
+        {
+            await Context.Client.SetGameAsync(gamename);
+            await ReplyAsync($"Changed game to {Context.Client.CurrentUser.Game?.Name}");
+        }
+
         public async Task<IRole> GetMuteRole(IGuild guild)
         {
             const string defaultMuteRoleName = "Muted";
@@ -190,8 +199,8 @@ namespace CommunityBot.Modules
             return muteRole;
         }
 
-        [Command("setAvatar")]
-        [RequireUserPermission(GuildPermission.Administrator)]
+        [Command("setAvatar"), Remarks("Sets the bots Avatar")]
+        [RequireOwner]
         public async Task SetAvatar(string link)
         {
             var s = Context.Message.DeleteAsync();

--- a/CommunityBot/Modules/Announcements.cs
+++ b/CommunityBot/Modules/Announcements.cs
@@ -5,9 +5,11 @@ using Discord.Commands;
 
 namespace CommunityBot.Modules
 {
+    [Group("Announcements"), Alias("Announcement"), Summary("Settings for announcements")]
+    [RequireUserPermission(GuildPermission.Administrator)]
     public class Announcement : ModuleBase<SocketCommandContext>
     {
-        [Command("setAnnouncementChannel"), Alias("setChannel"), RequireUserPermission(GuildPermission.Administrator)]
+        [Command("SetChannel"), Alias("Set"), RequireUserPermission(GuildPermission.Administrator)]
         [Remarks("Sets the channel where to post announcements")]
         public async Task SetAnnouncementChannel(ITextChannel channel)
         {
@@ -17,27 +19,25 @@ namespace CommunityBot.Modules
             await ReplyAsync("The Announcement-Channel has been set to " + channel.Mention);
         }
 
-        [Command("unsetAnnouncementChannel"), Alias("unsetChannel"), RequireUserPermission(GuildPermission.Administrator)]
+        [Command("UnsetChannel"), Alias("Unset", "Off"), RequireUserPermission(GuildPermission.Administrator)]
         [Remarks("Turns posting announcements to a channel off")]
         public async Task UnsetAnnouncementChannel()
         {
             var guildAcc = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id);
             guildAcc.AnnouncementChannelId = 0;
             GlobalGuildAccounts.SaveAccounts(Context.Guild.Id);
-            await ReplyAsync("Now there is no Announcement-Channel anymore! RIP");
+            await ReplyAsync("Now there is no Announcement-Channel anymore! No more Announcements from now on... RIP!");
         }
     }
     [Group("Welcome")]
-    [Summary("DM a joining user a random message out of the ones defined.\n" +
-             "Example: `welcome add <usermention>, Welcome to **<guildname>**. " +
-             "Try using ``@<botname>#<botdiscriminator> help`` for all the commands of <botmention>!`\n" +
-             "Possible placeholders are: `<usermention>`, `<username>`, `<guildname>`, " +
-             "`<botname>`, `<botdiscriminator>`, `<botmention>` ")
-    ]
+    [Summary("DM a joining user a random message out of the ones defined.")]
     public class WelcomeMessages : ModuleBase<SocketCommandContext>
     {
         [Command("add"), RequireUserPermission(GuildPermission.Administrator)]
-        
+        [Remarks("Example: `welcome add <usermention>, welcome to **<guildname>**! " +
+                 "Try using ```@<botname>#<botdiscriminator> help``` for all the commands of <botmention>!`\n" +
+                 "Possible placeholders are: `<usermention>`, `<username>`, `<guildname>`, " +
+                 "`<botname>`, `<botdiscriminator>`, `<botmention>` ")]
         public async Task AddWelcomeMessage([Remainder] string message)
         {
             var guildAcc = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id);
@@ -46,13 +46,14 @@ namespace CommunityBot.Modules
             {
                 guildAcc.WelcomeMessages.Add(message);
                 GlobalGuildAccounts.SaveAccounts(Context.Guild.Id);
-                response =  $"Successfully added ```{message}``` as Welcome Message!";
+                response =  $"Successfully added ```\n{message}\n``` as Welcome Message!";
             }
 
             await ReplyAsync(response);
         }
 
-        [Command("remove"), RequireUserPermission(GuildPermission.Administrator)]
+        [Command("remove"), Remarks("Removes a Welcome Message from the ones availabe")]
+        [RequireUserPermission(GuildPermission.Administrator)]
         public async Task RemoveWelcomeMessage(int messageIndex)
         {
             var messages = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id).WelcomeMessages;
@@ -67,7 +68,8 @@ namespace CommunityBot.Modules
             await ReplyAsync(response);
         }
 
-        [Command("list"), RequireUserPermission(GuildPermission.Administrator)]
+        [Command("list"), Remarks("Shows all currently set Welcome Messages")]
+        [RequireUserPermission(GuildPermission.Administrator)]
         public async Task ListWelcomeMessages()
         {
             var welcomeMessages = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id).WelcomeMessages;
@@ -84,15 +86,14 @@ namespace CommunityBot.Modules
 
     [Group("Leave")]
     [Summary("Announce a leaving user in the set announcement channel" +
-             "with a random message out of the ones defined.\n" +
-             "Example: `leave add <usermention>, left <guildname>...\n" +
-             "Possible placeholders are: `<usermention>`, `<username>`, `<guildname>`, " +
-             "`<botname>`, `<botdiscriminator>`, `<botmention>` ")
+             "with a random message out of the ones defined.")
     ]
     public class LeaveMessages : ModuleBase<SocketCommandContext>
     {
         [Command("add"), RequireUserPermission(GuildPermission.Administrator)]
-        [Remarks("Example: `leave add <usermention>, left <guildname>...")]
+        [Remarks("Example: `leave add Oh noo! <usermention>, left <guildname>...`\n" +
+                 "Possible placeholders are: `<usermention>`, `<username>`, `<guildname>`, " +
+                 "`<botname>`, `<botdiscriminator>`, `<botmention>`")]
         public async Task AddLeaveMessage([Remainder] string message)
         {
             var guildAcc = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id);
@@ -107,7 +108,8 @@ namespace CommunityBot.Modules
             await ReplyAsync(response);
         }
 
-        [Command("remove"), RequireUserPermission(GuildPermission.Administrator)]
+        [Command("remove"), Remarks("Removes a Leave Message from the ones available")]
+        [RequireUserPermission(GuildPermission.Administrator)]
         public async Task RemoveLeaveMessage(int messageIndex)
         {
             var messages = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id).LeaveMessages;
@@ -122,7 +124,8 @@ namespace CommunityBot.Modules
             await ReplyAsync(response);
         }
 
-        [Command("list"), RequireUserPermission(GuildPermission.Administrator)]
+        [Command("list"), Remarks("Shows all currently set Leave Messages")]
+        [RequireUserPermission(GuildPermission.Administrator)]
         public async Task ListLeaveMessages()
         {
             var leaveMessages = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id).LeaveMessages;

--- a/CommunityBot/Modules/Blogs.cs
+++ b/CommunityBot/Modules/Blogs.cs
@@ -12,11 +12,11 @@ using Newtonsoft.Json;
 
 namespace CommunityBot.Modules
 {
-    [Group("Blog")]
+    [Group("Blog"), Summary("Enables you to create a block that people can subscribe to so they don't miss out if you publish a new one")]
     public class Blogs : ModuleBase<SocketCommandContext>
     {
         private static readonly string blogFile = "blogs.json";
-        [Command("Create")]
+        [Command("Create"), Remarks("Create a new named block")]
         public async Task Create(string name)
         {
             await Context.Message.DeleteAsync();
@@ -47,7 +47,7 @@ namespace CommunityBot.Modules
             }
         }
 
-        [Command("Post")]
+        [Command("Post"), Remarks("Publish a new post to one of your named blocks")]
         public async Task Post(string name, [Remainder]string post)
         {
             await Context.Message.DeleteAsync();
@@ -85,7 +85,7 @@ namespace CommunityBot.Modules
             }
         }
 
-        [Command("Subscribe")]
+        [Command("Subscribe"), Remarks("Subscribe to a named blog to receive a message when a new post gets published")]
         public async Task Subscribe(string name)
         {
             await Context.Message.DeleteAsync();
@@ -95,7 +95,7 @@ namespace CommunityBot.Modules
             await Context.Channel.SendMessageAsync("", false, embed);
         }
 
-        [Command("Unsubscribe")]
+        [Command("Unsubscribe"), Remarks("Remove a subscription from a named block")]
         public async Task UnSubscribe(string name)
         {
             await Context.Message.DeleteAsync();

--- a/CommunityBot/Modules/Economy.cs
+++ b/CommunityBot/Modules/Economy.cs
@@ -13,7 +13,7 @@ namespace CommunityBot.Modules
 {
     public class Economy : ModuleBase<SocketCommandContext>
     {
-        [Command("Daily")]
+        [Command("Daily"), Remarks("Gives you some Miunies but can only be used once a day")]
         [Alias("GetDaily", "ClaimDaily")]
         public async Task GetDaily()
         {
@@ -29,7 +29,7 @@ namespace CommunityBot.Modules
             }
         }
 
-        [Command("Miunies")]
+        [Command("Miunies"), Remarks("Shows how many Miunies you have")]
         [Alias("Cash", "Money")]
         public async Task CheckMiunies()
         {
@@ -37,7 +37,7 @@ namespace CommunityBot.Modules
             await ReplyAsync(GetMiuniesReport(account.Miunies, Context.User.Mention));
         }
 
-        [Command("Miunies")]
+        [Command("Miunies"), Remarks("Shows how many Miunies the mentioned user has")]
         [Alias("Cash", "Money")]
         public async Task CheckMiuniesOther(IGuildUser target)
         {
@@ -73,7 +73,7 @@ namespace CommunityBot.Modules
             return $"{mention} has **{miunies} miunies**! {GetMiuniesCountReaction(miunies, mention)} \n\nDid you know?\n`{Global.GetRandomDidYouKnow()}`";
         }
 
-        [Command("newslot")]
+        [Command("newslot"), Remarks("Creates a new slot machine if you feel the current one is unlucky")]
         [Alias("newslots")]
         public async Task NewSlot(int amount = 0)
         {
@@ -81,7 +81,7 @@ namespace CommunityBot.Modules
             await ReplyAsync("A new slotmachine got generated! Good luck with this puppy!");
         }
 
-        [Command("slots")]
+        [Command("slots"), Remarks("Play the slots! Win or lose some Miunies!")]
         [Alias("slot")]
         public async Task SpinSlot(uint amount)
         {
@@ -114,7 +114,7 @@ namespace CommunityBot.Modules
             await ReplyAsync(payoutAndFlavour.Item2);
         }
 
-        [Command("showslots")]
+        [Command("showslots"), Remarks("Shows the configuration of the current slot machine")]
         [Alias("showslot")]
         public async Task ShowSlot()
         {

--- a/CommunityBot/Modules/Misc.cs
+++ b/CommunityBot/Modules/Misc.cs
@@ -4,6 +4,7 @@ using Discord.Commands;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -18,80 +19,127 @@ namespace CommunityBot.Modules
             _service = service;
         }
 
-        [Command("help")]
         [Cooldown(15)]
+        [Command("help"), Alias("h"), Remarks("DMs you a huge message if called without parameter - otherwise shows help to the provided command or module")]
         public async Task Help()
         {
-
             await Context.Channel.SendMessageAsync("Check your DMs.");
 
             var dmChannel = await Context.User.GetOrCreateDMChannelAsync();
 
+            var contextString = Context.Guild?.Name ?? "DMs with me";
             var builder = new EmbedBuilder()
             {
                 Title = "Help",
-                Description = "These are the commands you can use",
+                Description = $"These are the commands you can use in {contextString}",
                 Color = new Color(114, 137, 218)
             };
 
             foreach (var module in _service.Modules)
             {
-                string description = null;
-                var descriptionBuilder = new List<string>();
-                foreach (var cmd in module.Commands)
-                {
-                    var result = await cmd.CheckPreconditionsAsync(Context);
-                    if (result.IsSuccess && !descriptionBuilder.Contains(cmd.Aliases.First()))
-                        descriptionBuilder.Add(cmd.Aliases.First());
-                }
-                description = String.Join("\n", descriptionBuilder);
-
-                if (!string.IsNullOrWhiteSpace(description))
-                {
-                    builder.AddField(x =>
-                    {
-                        x.Name = module.Name;
-                        x.Value = description;
-                        x.IsInline = false;
-                    });
-                }
+                await AddModuleEmbedField(module, builder);
             }
+
             await dmChannel.SendMessageAsync("", false, builder.Build());
+
+            // Embed are limited to 24 Fields at max. So lets clear some stuff
+            // out and then send it in multiple embeds if it is too big.
+            builder.WithTitle("")
+                .WithDescription("")
+                .WithAuthor("");
+            while (builder.Fields.Count > 24)
+            {
+                builder.Fields.RemoveRange(0, 25);
+                await dmChannel.SendMessageAsync("", false, builder.Build());
+                
+            }
         }
 
-        [Command("help")]
-        [Remarks("Shows what a specific command does and what parameters it takes.")]
+        [Command("help"), Alias("h")]
+        [Remarks("Shows what a specific command or module does and what parameters it takes.")]
         [Cooldown(5)]
-        public async Task HelpCommand(string command)
+        public async Task HelpQuery([Remainder]string query)
         {
-            var dmChannel = await Context.User.GetOrCreateDMChannelAsync();
-            var result = _service.Search(Context, command);
-
-            if (!result.IsSuccess)
-            {
-                await ReplyAsync($"Sorry, I couldn't find a command like {command}.");
-                return;
-            }
-
             var builder = new EmbedBuilder()
             {
                 Color = new Color(114, 137, 218),
-                Description = $"Here are commands related to {command}"
+                Title = $"Help for '{query}'"
             };
 
-            foreach (var match in result.Commands)
+            var result = _service.Search(Context, query);
+            if (query.StartsWith("module "))
+                query = query.Remove(0, "module ".Length);
+            var emb = result.IsSuccess ? HelpCommand(result, builder) : await HelpModule(query, builder);
+
+            if (emb.Fields.Length == 0)
+            {
+                await ReplyAsync($"Sorry, I couldn't find anything for \"{query}\".");
+                return;
+            }
+
+            await Context.Channel.SendMessageAsync("", false, emb);
+        }
+
+        private static Embed HelpCommand(SearchResult search, EmbedBuilder builder)
+        {
+            foreach (var match in search.Commands)
             {
                 var cmd = match.Command;
+                var parameters = cmd.Parameters.Select(p => string.IsNullOrEmpty(p.Summary) ? p.Name : p.Summary);
+                var paramsString = $"Parameters: {string.Join(", ", parameters)}" +
+                                (string.IsNullOrEmpty(cmd.Remarks) ? "" : $"\nRemarks: {cmd.Remarks}") +
+                                (string.IsNullOrEmpty(cmd.Summary) ? "" : $"\nSummary: {cmd.Summary}");
 
                 builder.AddField(x =>
                 {
                     x.Name = string.Join(", ", cmd.Aliases);
-                    x.Value = $"Parameters: {string.Join(", ", cmd.Parameters.Select(p => p.Name))}\n" +
-                                $"Remarks: {cmd.Remarks}";
+                    x.Value = paramsString;
                     x.IsInline = false;
                 });
             }
-            await Context.Channel.SendMessageAsync("", false, builder.Build());
+
+            return builder.Build();
+        }
+
+        private async Task<Embed> HelpModule(string moduleName, EmbedBuilder builder)
+        {
+            var module = _service.Modules.ToList().Find(mod => string.Equals(mod.Name, moduleName, StringComparison.CurrentCultureIgnoreCase));
+            await AddModuleEmbedField(module, builder);
+            return builder.Build();
+        }
+
+        private async Task AddModuleEmbedField(ModuleInfo module, EmbedBuilder builder)
+        {
+            if (module == null) return;
+            var descriptionBuilder = new List<string>();
+            var duplicateChecker = new List<string>();
+            foreach (var cmd in module.Commands)
+            {
+                var result = await cmd.CheckPreconditionsAsync(Context);
+                if (!result.IsSuccess || duplicateChecker.Contains(cmd.Aliases.First())) continue;
+                duplicateChecker.Add(cmd.Aliases.First());
+                var cmdDescription = $"`{cmd.Aliases.First()}`";
+                if (string.IsNullOrEmpty(cmd.Summary) == false)
+                    cmdDescription +=  $" | {cmd.Summary}";
+                if (string.IsNullOrEmpty(cmd.Remarks) == false)
+                    cmdDescription +=  $" | {cmd.Remarks}";
+                if (cmdDescription != "``")
+                    descriptionBuilder.Add(cmdDescription);
+            }
+
+            if (descriptionBuilder.Count <= 0) return;
+
+            var moduleNotes = "";
+            if (string.IsNullOrEmpty(module.Summary) == false)
+                moduleNotes +=  $" {module.Summary}";
+            if (string.IsNullOrEmpty(module.Remarks) == false)
+                moduleNotes +=  $" {module.Remarks}";
+            if (string.IsNullOrEmpty(moduleNotes) == false)
+                moduleNotes += "\n";
+            if (string.IsNullOrEmpty(module.Name) == false)
+            {
+                builder.AddField($"__**{module.Name}:**__", $"{moduleNotes}" + string.Join("\n", descriptionBuilder) + $"\n{Constants.InvisibleString}");
+            }
         }
 
         [Command("Addition")]

--- a/CommunityBot/Modules/Prefix.cs
+++ b/CommunityBot/Modules/Prefix.cs
@@ -11,10 +11,12 @@ using Discord.Commands;
 
 namespace CommunityBot.Modules
 {
-    [Group("Prefix"), Alias("Prefixes")]
+    [Group("Prefix"), Alias("Prefixes"), Summary("Setting for the Bots prefix on this server")]
+    [RequireContext(ContextType.Guild)]
     public class Prefix : ModuleBase<SocketCommandContext>
     {
         [Command("add"), Alias("set"), RequireUserPermission(GuildPermission.Administrator)]
+        [Remarks("Adds a prefix to the list of prefixes")]
         public async Task AddPrefix([Remainder] string prefix)
         {
             var guildAcc = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id);
@@ -29,7 +31,8 @@ namespace CommunityBot.Modules
             await ReplyAsync(response);
         }
 
-        [Command("remove"), RequireUserPermission(GuildPermission.Administrator)]
+        [Command("remove"), Remarks("Removes a prefix from the list of prefixes")] 
+        [RequireUserPermission(GuildPermission.Administrator)]
         public async Task RemovePrefix([Remainder] string prefix)
         {
             var guildAcc = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id);
@@ -44,7 +47,7 @@ namespace CommunityBot.Modules
             await ReplyAsync(response);
         }
 
-        [Command("list")]
+        [Command("list"), Remarks("Show all possible prefixes for this server")]
         public async Task ListPrefixes()
         {
             var prefixes = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id).Prefixes;

--- a/CommunityBot/Modules/RepeatedTasks.cs
+++ b/CommunityBot/Modules/RepeatedTasks.cs
@@ -5,7 +5,7 @@ using Discord.Commands;
 
 namespace CommunityBot.Modules
 {
-    [Group("Tasks")] 
+    [Group("Tasks"), Remarks("Settings for the repeated task that run in the background")] 
     [Alias("Task", "T")]
     public class RepeatedTasks : ModuleBase<SocketCommandContext>
     {


### PR DESCRIPTION
- Help now contains a lot more information depending on Summaries and Remarks you provide in the code.
  - `help` without parameters DMs a complete help message with all commands
  - `help <command>` shows the usage of this command with parameters ~~similar commands can show up~~
  - `help <modulename>` shows help for the module - if the modulename is amibious because a command is named the same use `help module <modulename>`
- Added a bunch of Summaries and Remarks for commands
- Modified some command requirements (for example only the botowner should be able to change the bot avatar)
- Added command to change what the bot is playing `game <game name>`