### PR TITLE
Fixing Command 'top' / 'richest'

### DIFF
--- a/CommunityBot/Modules/Economy.cs
+++ b/CommunityBot/Modules/Economy.cs
@@ -80,10 +80,11 @@ namespace CommunityBot.Modules
             // Add fields to the embed with information of users according to the provided page we should show
             // Two conditions because:  1. Only get as many as we want 
             //                          2. The last page might not be completely filled so we have to interrupt early
-            for (var i = 0; i < usersPerPage && i + usersPerPage * (page - 1) < ordered.Count; i++)
+            page--;
+            for (var i = 1; i <= usersPerPage && i + usersPerPage * page <= ordered.Count; i++)
             {
                 // -1 because we take the users non zero based input
-                var account = ordered[i + usersPerPage * (page - 1)];
+                var account = ordered[i - 1 + usersPerPage * page];
                 var user = Global.Client.GetUser(account.Id);
                 embB.AddField($"#{i + usersPerPage * page} {user.Username}", $"{account.Miunies} Miunies", true);
             }


### PR DESCRIPTION
By making the changes to achieve more readability of the code I missed that I had to change some more code further down in the function...
Error was that it resulted in wrong displaying of the #rank (page 1 went from # 9 to # 17 instead of # 1 to # 9)