### PR TITLE
Discord Extensions

### DIFF
--- a/CommunityBot/Helpers/DiscordExtensions.cs
+++ b/CommunityBot/Helpers/DiscordExtensions.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+
+namespace CommunityBot.Helpers
+{
+    public static class DiscordExtensions
+    {
+        // Extensions for Discord Class SocketGuild
+        public static SocketGuildUser FirstUserByName(this SocketGuild guild, string name)
+        {
+            if (MentionUtils.TryParseUser(name, out var id))
+                return guild.Users.FirstOrDefault(user => user.Id == id);
+
+            return guild.Users.FirstOrDefault(user =>
+                Regex.IsMatch(user.Username, name, RegexOptions.IgnoreCase)||
+                Regex.IsMatch(user.Nickname ?? "", name, RegexOptions.IgnoreCase)
+            );
+        }
+
+        public static SocketTextChannel FirstTextChannelByName(this SocketGuild guild, string name)
+        {
+            if (MentionUtils.TryParseChannel(name, out var id))
+                return guild.TextChannels.FirstOrDefault(channel => channel.Id == id);
+
+            return guild.TextChannels.FirstOrDefault(channel =>
+                Regex.IsMatch(channel.Name, name, RegexOptions.IgnoreCase)
+            );
+        }
+
+        public static SocketVoiceChannel FirstVoiceChannelByName(this SocketGuild guild, string name)
+        {
+            if (MentionUtils.TryParseChannel(name, out var id))
+                return guild.VoiceChannels.FirstOrDefault(channel => channel.Id == id);
+
+            return guild.VoiceChannels.FirstOrDefault(channel =>
+                Regex.IsMatch(channel.Name, name, RegexOptions.IgnoreCase)
+            );
+        }
+
+        public static SocketRole FirstRoleByName(this SocketGuild guild, string name)
+        {
+            if (MentionUtils.TryParseRole(name, out var id))
+                return guild.Roles.FirstOrDefault(role => role.Id == id);
+
+            return guild.Roles.FirstOrDefault(role =>
+                Regex.IsMatch(role.Name, name, RegexOptions.IgnoreCase)
+            );
+        }
+
+        /// <summary>
+        /// Extended function that creates an awaitable Task which resolves in the first SocketMessage send in this channel 
+        /// that matches the provided filter - times out after a set time
+        /// </summary>
+        /// <param name="channel"></param>
+        /// <param name="filter">Optional - if not provided first message in channel is match</param>
+        /// <param name="timeoutInMs">Optional - if not provided 30 seconds</param>
+        /// <returns>Awaitable Task which resolves in the first SocketMessage that matches the filter</returns>
+        public static async Task<SocketMessage> AwaitMessage(this IMessageChannel channel, Func<SocketMessage, bool> filter = null, int timeoutInMs = 30000)
+        {
+            SocketMessage responseMessage = null;
+            var cancler = new CancellationTokenSource();
+            var waiter = Task.Delay(timeoutInMs, cancler.Token);
+
+            // Adding function that handles filtering and 
+            // assigning the respondMessage the correct value
+            Global.Client.MessageReceived += OnMessageReceived;
+            // Waiting for the timeout to run out or the task.Delay to be canceled due to a matched message
+            try { await waiter; }
+            catch (TaskCanceledException) { }
+            // Remove the function from the 
+            Global.Client.MessageReceived -= OnMessageReceived;
+            return responseMessage;
+
+            Task OnMessageReceived(SocketMessage message)
+            {
+                if (message.Channel != channel)
+                    return Task.CompletedTask;
+                if (filter != null && filter(message) == false)
+                    return Task.CompletedTask;
+                responseMessage = message;
+                cancler.Cancel();
+                return Task.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- IMessageChannel extension:

  "AwaitMessage" that creates an awaitable Task which resolves in the first SocketMessage send in this channel that matches the provided filter - times out after a set time.
  Optional parameters are:
  - Filter of type Function<SocketMessage, bool>
    For example: message => message.Author == Context.User

    Defaults to null which means the first message is a match
  - Timeout in milliseconds
    Defaults to 30000

- SocketGuild extensions:

  "FirstUserByName", "FirstTextChannelByName", "FirstVoiceChannelByName", "FirstRoleByName"

  - All these work very similar and accept either a name or an actual mention string and return the correct object or null if none was found.
  - "FirstUserByName" checks Username and also Nickname if the user has one.
  - Can for example be used to remove the neccessarity of mentioning users in Miunie transfers