### PR TITLE
Modify GlobalGuildAccount

### DIFF
--- a/CommunityBot/Entities/GlobalGuildAccount.cs
+++ b/CommunityBot/Entities/GlobalGuildAccount.cs
@@ -1,5 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CommunityBot.Features.GlobalAccounts;
 using CommunityBot.Features.RoleAssignment;
+using Discord;
+using static CommunityBot.Modules.ServerBots;
 
 namespace CommunityBot.Entities
 {
@@ -7,20 +12,65 @@ namespace CommunityBot.Entities
     {
         public ulong Id { get; set; }
 
-        public ulong AnnouncementChannelId { get; set; }
+        public ulong AnnouncementChannelId { get; private set; }
 
-        public List<string> Prefixes { get; set; } = new List<string>();
+        public IReadOnlyList<string> Prefixes { get; private set; } = new List<string>();
 
-        public List<string> WelcomeMessages { get; set; } = new List<string> { };
+        public IReadOnlyList<string> WelcomeMessages { get; private set; } = new List<string> { };
 
-        public List<string> LeaveMessages { get; set; } = new List<string>();
+        public IReadOnlyList<string> LeaveMessages { get; private set; } = new List<string>();
 
-        public Dictionary<string, string> Tags { get; set; } = new Dictionary<string, string>();
+        public Dictionary<string, string> Tags { get; private set; } = new Dictionary<string, string>();
 
-        public Modules.ServerBots.GuildData BotData { get; set; }
+        public Modules.ServerBots.GuildData BotData { get; private set; }
 
-        public RoleByPhraseSettings RoleByPhraseSettings { get; set; } = new RoleByPhraseSettings();
+        public RoleByPhraseSettings RoleByPhraseSettings { get; private set; } = new RoleByPhraseSettings();
 
         /* Add more values to store */
+        public GlobalGuildAccount Modify(Action<GuildAccountSettings> func)
+        {
+            var settings = new GuildAccountSettings();
+            func(settings);
+
+            if (settings.AnnouncementChannelId.IsSpecified)
+                AnnouncementChannelId = settings.AnnouncementChannelId.Value;
+            if (settings.Prefixes.IsSpecified)
+                Prefixes = settings.Prefixes.Value;
+            if (settings.WelcomeMessages.IsSpecified)
+                WelcomeMessages = settings.WelcomeMessages.Value;
+            if (settings.LeaveMessages.IsSpecified)
+                LeaveMessages = settings.LeaveMessages.Value;
+            if (settings.Tags.IsSpecified)
+                Tags = settings.Tags.Value;
+            if (settings.BotData.IsSpecified)
+                BotData = settings.BotData.Value;
+            if (settings.RoleByPhraseSettings.IsSpecified)
+                RoleByPhraseSettings = settings.RoleByPhraseSettings.Value;
+            GlobalGuildAccounts.SaveAccounts(Id);
+            return this;
+        }
+    }
+    public class GuildAccountSettings
+    {
+        public Optional<ulong> AnnouncementChannelId { get; private set; }
+        public GuildAccountSettings SetAnnouncementChannelId(ulong id) { AnnouncementChannelId = id; return this; }
+
+        public Optional<List<string>> Prefixes { get; private set; }
+        public GuildAccountSettings SetPrefixes(List<string> prefixes) { Prefixes = prefixes; return this; }
+
+        public Optional<List<string>> WelcomeMessages { get; private set; }
+        public GuildAccountSettings SetWelcomeMessages(List<string> welcomeMessages) { WelcomeMessages = welcomeMessages; return this; }
+
+        public Optional<List<string>> LeaveMessages { get; private set; }
+        public GuildAccountSettings SetLeaveMessages(List<string> leaveMessages) { LeaveMessages = leaveMessages; return this; }
+
+        public Optional<Dictionary<string, string>> Tags { get; private set; }
+        public GuildAccountSettings SetTags(Dictionary<string, string> tags) { Tags = tags; return this; }
+
+        public Optional<GuildData> BotData { get; private set; }
+        public GuildAccountSettings SetBotData(GuildData botData) { BotData = botData; return this; }
+
+        public Optional<RoleByPhraseSettings> RoleByPhraseSettings { get; private set; }
+        public GuildAccountSettings SetBotData(RoleByPhraseSettings roleByPhraseSettings) { RoleByPhraseSettings = roleByPhraseSettings; return this; }
     }
 }

--- a/CommunityBot/Entities/GlobalUserAccount.cs
+++ b/CommunityBot/Entities/GlobalUserAccount.cs
@@ -17,7 +17,7 @@ namespace CommunityBot.Entities
         public DateTime LastMessage { get; set; } = DateTime.UtcNow;
 
         public Dictionary<string, string> Tags { get; set; } = new Dictionary<string, string>();
-        
+
         public List<ReminderEntry> Reminders { get; internal set; } = new List<ReminderEntry>();
         /* Add more values to store */
     }

--- a/CommunityBot/Entities/IGlobalAccount.cs
+++ b/CommunityBot/Entities/IGlobalAccount.cs
@@ -9,6 +9,6 @@ namespace CommunityBot.Entities
     public interface IGlobalAccount
     {
         ulong Id { get; set; }
-        Dictionary<string, string> Tags { get; set; }
+        Dictionary<string, string> Tags { get; }
     }
 }

--- a/CommunityBot/Modules/Announcements.cs
+++ b/CommunityBot/Modules/Announcements.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using CommunityBot.Features.GlobalAccounts;
 using Discord;
 using Discord.Commands;
@@ -14,8 +15,7 @@ namespace CommunityBot.Modules
         public async Task SetAnnouncementChannel(ITextChannel channel)
         {
             var guildAcc = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id);
-            guildAcc.AnnouncementChannelId = channel.Id;
-            GlobalGuildAccounts.SaveAccounts(Context.Guild.Id);
+            guildAcc.Modify(g => g.SetAnnouncementChannelId(channel.Id));
             await ReplyAsync("The Announcement-Channel has been set to " + channel.Mention);
         }
 
@@ -24,8 +24,7 @@ namespace CommunityBot.Modules
         public async Task UnsetAnnouncementChannel()
         {
             var guildAcc = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id);
-            guildAcc.AnnouncementChannelId = 0;
-            GlobalGuildAccounts.SaveAccounts(Context.Guild.Id);
+            guildAcc.Modify(g => g.SetAnnouncementChannelId(0));
             await ReplyAsync("Now there is no Announcement-Channel anymore! No more Announcements from now on... RIP!");
         }
     }
@@ -44,8 +43,9 @@ namespace CommunityBot.Modules
             var response = $"Failed to add this Welcome Message...";
             if (guildAcc.WelcomeMessages.Contains(message) == false)
             {
-                guildAcc.WelcomeMessages.Add(message);
-                GlobalGuildAccounts.SaveAccounts(Context.Guild.Id);
+                var messages = guildAcc.WelcomeMessages.ToList();
+                messages.Add(message);
+                guildAcc.Modify(g => g.SetWelcomeMessages(messages));
                 response =  $"Successfully added ```\n{message}\n``` as Welcome Message!";
             }
 
@@ -56,12 +56,13 @@ namespace CommunityBot.Modules
         [RequireUserPermission(GuildPermission.Administrator)]
         public async Task RemoveWelcomeMessage(int messageIndex)
         {
-            var messages = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id).WelcomeMessages;
+            var guildAcc = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id);
+            var messages = guildAcc.WelcomeMessages.ToList();
             var response = $"Failed to remove this Welcome Message... Use the number shown in `welcome list` next to the `#` sign!";
             if (messages.Count > messageIndex - 1)
             {
                 messages.RemoveAt(messageIndex - 1);
-                GlobalGuildAccounts.SaveAccounts(Context.Guild.Id);
+                guildAcc.Modify(g => g.SetWelcomeMessages(messages));
                 response =  $"Successfully removed message #{messageIndex} as possible Welcome Message!";
             }
 
@@ -100,8 +101,9 @@ namespace CommunityBot.Modules
             var response = $"Failed to add this Leave Message...";
             if (guildAcc.LeaveMessages.Contains(message) == false)
             {
-                guildAcc.LeaveMessages.Add(message);
-                GlobalGuildAccounts.SaveAccounts(Context.Guild.Id);
+                var messages = guildAcc.WelcomeMessages.ToList();
+                messages.Add(message);
+                guildAcc.Modify(g => g.SetLeaveMessages(messages));
                 response =  $"Successfully added `{message}` as Leave Message!";
             }
 
@@ -112,12 +114,13 @@ namespace CommunityBot.Modules
         [RequireUserPermission(GuildPermission.Administrator)]
         public async Task RemoveLeaveMessage(int messageIndex)
         {
-            var messages = GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id).LeaveMessages;
+            var guildAcc= GlobalGuildAccounts.GetGuildAccount(Context.Guild.Id);
+            var messages = guildAcc.LeaveMessages.ToList();
             var response = $"Failed to remove this Leave Message... Use the number shown in `leave list` next to the `#` sign!";
             if (messages.Count > messageIndex - 1)
             {
                 messages.RemoveAt(messageIndex - 1);
-                GlobalGuildAccounts.SaveAccounts(Context.Guild.Id);
+                guildAcc.Modify(g => g.SetLeaveMessages(messages));
                 response =  $"Successfully removed message #{messageIndex} as possible Welcome Message!";
             }
 

--- a/CommunityBot/Modules/Prefix.cs
+++ b/CommunityBot/Modules/Prefix.cs
@@ -23,15 +23,15 @@ namespace CommunityBot.Modules
             var response = $"Failed to add the Prefix... Was `{prefix}` already a prefix?";
             if (guildAcc.Prefixes.Contains(prefix) == false)
             {
-                guildAcc.Prefixes.Add(prefix);
-                GlobalGuildAccounts.SaveAccounts(Context.Guild.Id);
+                var prefixes = guildAcc.Prefixes.ToList();
+                guildAcc.Modify(g => g.SetPrefixes(prefixes.Append(prefix).ToList()));
                 response =  $"Successfully added `{prefix}` as prefix!";
             }
 
             await ReplyAsync(response);
         }
 
-        [Command("remove"), Remarks("Removes a prefix from the list of prefixes")] 
+        [Command("remove"), Remarks("Removes a prefix from the list of prefixes")]
         [RequireUserPermission(GuildPermission.Administrator)]
         public async Task RemovePrefix([Remainder] string prefix)
         {
@@ -39,8 +39,9 @@ namespace CommunityBot.Modules
             var response = $"Failed to remove the Prefix... Was `{prefix}` really a prefix?";
             if (guildAcc.Prefixes.Contains(prefix))
             {
-                guildAcc.Prefixes.Remove(prefix);
-                GlobalGuildAccounts.SaveAccounts(Context.Guild.Id);
+                var prefixes = guildAcc.Prefixes.ToList();
+                prefixes.Remove(prefix);
+                guildAcc.Modify(g => g.SetPrefixes(prefixes));
                 response =  $"Successfully removed `{prefix}` as possible prefix!";
             }
 

--- a/CommunityBot/Modules/ServerBots.cs
+++ b/CommunityBot/Modules/ServerBots.cs
@@ -174,8 +174,8 @@ namespace CommunityBot.Modules
 
         static void StoreData(ulong id)
         {
-            GlobalGuildAccounts.GetGuildAccount(id).BotData = data.GetGuild(id);
-            GlobalGuildAccounts.SaveAccounts(id);
+            var guildAccount = GlobalGuildAccounts.GetGuildAccount(id);
+            guildAccount.Modify(g => g.SetBotData(data.GetGuild(id)));
         }
 
         [Command("add")]
@@ -249,7 +249,7 @@ namespace CommunityBot.Modules
                     await ReplyAsync("You're really going to try that one on me??");
                     return;
                 }
-                
+
                 List<Submission> list;
                 if (args[1] == "pending")
                     list = data.GetGuild(Context.Guild.Id).queue;
@@ -289,8 +289,8 @@ namespace CommunityBot.Modules
                             int index = i + (SUBMISSIONS_PER_PAGE * (page - 1));
 
                             if (index < list.Count)
-                            builder.Description += $"{index + 1}. [{list[index].name}]({LINK_TEMPLATE_FIRST + list[index].botId + LINK_TEMPLATE_LAST})" + 
-                                $"by **{Global.Client.GetUser(list[index].userId).Username}**:\n{list[index].description}\n" + 
+                            builder.Description += $"{index + 1}. [{list[index].name}]({LINK_TEMPLATE_FIRST + list[index].botId + LINK_TEMPLATE_LAST})" +
+                                $"by **{Global.Client.GetUser(list[index].userId).Username}**:\n{list[index].description}\n" +
                                 $"*Client ID: {list[index].botId}*\n{list[index].timeSent} {TimeZone.CurrentTimeZone.StandardName}\n\n";
                         }
                         catch (IndexOutOfRangeException)


### PR DESCRIPTION
Implemented Modify function for GlobalGuildAccount which disallows the manipulation of properties of GlobalGuildAccount objects without accidentally forgetting to save them.
Syntax is as followed (as suggested in Discord):
```cs
guildAcc.Modyfiy(guild => guild.SetPrefixes(prefixes).SetBotData(botData));
```

**PRO:**
Foolproof. No one can just use a guildAccount object and manipulate data without saving due to private setters and the functions that set the data (e.g. SetBotData) not being part of the GlobalGuildAccount class.
(Btw this is how Discord.Net is doing it (well without the function chaining but the rest...) I got 'inspiration' from them... e.g. socketGuildUser.Modify(gUsr => gUsr.Nickname = "something"));

**CON:**
It is a little more complicated and longer to set up new properties for GlobalGuildAccount

> Implemented only for GlobalGuildAccount but if this will get approved I will apply it to GlobalUserAccounts as well.