### PR TITLE
Add option to log into file, console, or both

### DIFF
--- a/CommunityBot/Configuration/ApplicationSettings.cs
+++ b/CommunityBot/Configuration/ApplicationSettings.cs
@@ -9,6 +9,8 @@ namespace CommunityBot.Configuration
         public readonly bool Verbose;
         public readonly int ChacheSize;
         public readonly bool LoggerDownloadingAttachment;
+        public readonly bool LogIntoFile;
+        public readonly bool LogIntoConsole;
 
         public ApplicationSettings(string [] args)
         {
@@ -23,7 +25,8 @@ namespace CommunityBot.Configuration
                     "-hl                    : run in headless mode (no output to console)\n" +
                     "-vb                    : run with verbose discord logging\n" +
                     "-token=<token>         : run with specific token instead of the saved one in bot configs\n" +
-                    "-cs=<number>           : message cache size per channel (defaults to 0)"
+                    "-cs=<number>           : message cache size per channel (defaults to 0)" +
+                    "-log=<f | c>           : log into a (f)ile, (c)onsole  or both. Default is console"
                 );
                 return;
             }
@@ -59,6 +62,28 @@ namespace CommunityBot.Configuration
             // Downloading Attachemnts for Activity Logger -att
             if (args.Contains("-att"))
             LoggerDownloadingAttachment = true;
+
+            // Log output handling -log=<f | c>
+            //f = file c = console
+            // Default is (c)onsole
+            LogIntoConsole = true;
+            LogIntoFile = false;
+            if (args.Any(arg => arg.StartsWith("-log=")))
+            {
+                var options = args.FirstOrDefault(arg => arg.StartsWith("-log="))?.Replace("-log=", "");
+                if (options.Contains("f") && options.Contains("c"))
+                {
+                    LogIntoFile = true;
+                    LogIntoConsole = true;
+                }
+                else if (options.Contains("f"))
+                {
+                    LogIntoConsole = false;
+                    LogIntoFile = true;
+                }
+            }
+            Global.LogIntoConsole = LogIntoConsole;
+            Global.LogIntoFile = LogIntoFile;
         }
 
     }

--- a/CommunityBot/Constants.cs
+++ b/CommunityBot/Constants.cs
@@ -11,6 +11,7 @@ namespace CommunityBot
         internal static readonly string ResourceFolder = "resources";
         internal static readonly string UserAccountsFolder = "users";
         internal static readonly string ServerAccountsFolder = "servers";
+        internal static readonly string LogFolder = "logs";
         internal static readonly string InvisibleString = "\u200b";
         public const ulong DailyMuiniesGain = 250;
         public const int MessageRewardCooldown = 30;

--- a/CommunityBot/Global.cs
+++ b/CommunityBot/Global.cs
@@ -27,6 +27,8 @@ namespace CommunityBot
         internal static RepeatedTaskHandler TaskHander = new RepeatedTaskHandler();
         internal static readonly String version = Assembly.GetExecutingAssembly().GetName().Version.ToString().TrimEnd('0').TrimEnd('.');
 
+        internal static bool LogIntoFile;
+        internal static bool LogIntoConsole;
         internal static bool Headless = false;
         // Global Helper methods
 

--- a/CommunityBot/Logger.cs
+++ b/CommunityBot/Logger.cs
@@ -1,9 +1,9 @@
-﻿using Discord;
+﻿
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.IO;
 using System.Threading.Tasks;
+using Discord;
 
 namespace CommunityBot
 {
@@ -11,11 +11,34 @@ namespace CommunityBot
     {
         internal static Task Log(LogMessage logMessage)
         {
-            Console.ForegroundColor = SeverityToConsoleColor(logMessage.Severity);
             string message = String.Concat(DateTime.Now.ToShortTimeString(), " [", logMessage.Source, "] ", logMessage.Message);
+            LogConsole(message, logMessage.Severity);
+            LogFile(message);
+            return Task.CompletedTask;
+        }
+
+        private static void LogFile(string message)
+        {
+            if (!Global.LogIntoFile) return;
+
+            var fileName = $"{DateTime.Today.Day}-{DateTime.Today.Month}-{DateTime.Today.Year}.log";
+            var folder = Constants.LogFolder;
+
+            if (!Directory.Exists(folder))
+                Directory.CreateDirectory(folder);
+
+            StreamWriter sw = File.AppendText($"{folder}/{fileName}");
+            sw.WriteLine(message);
+            sw.Close();
+        }
+
+        private static void LogConsole(string message, LogSeverity severity)
+        {
+            if (!Global.LogIntoConsole) return;
+
+            Console.ForegroundColor = SeverityToConsoleColor(severity);
             Console.WriteLine(message);
             Console.ResetColor();
-            return Task.CompletedTask;
         }
 
         private static ConsoleColor SeverityToConsoleColor(LogSeverity severity)


### PR DESCRIPTION
I did add parameter for the Main(string[] args) to enable logging into a file instead of a console output, or both, as stated in this issue #49 

The parameter is _-log=<c | f>_, default value is (c)onsole.

Something I dislike about what I did is, I need to use the Global class to let the Logger know how is the application configurated. Also, every time the Log function is called, checks if the logs directory exists. The usage of Dependency Injection for the Logger class would fix this.