### PR TITLE
Modify Admin module, create RequireBotHigherHirachy attribute precondition, and convert TriviaGames into a service with DI

### DIFF
--- a/CommunityBot/Features/Trivia/TriviaGame.cs
+++ b/CommunityBot/Features/Trivia/TriviaGame.cs
@@ -8,7 +8,7 @@ using Discord.WebSocket;
 
 namespace CommunityBot.Features.Trivia
 {
-    internal class TriviaGame
+    public class TriviaGame
     {
         // Used to identify which reactions to actually react to
         internal ulong PlayerId;
@@ -26,21 +26,24 @@ namespace CommunityBot.Features.Trivia
         private EmbedBuilder _emb;
         private int _currentCategoryPage;
 
+        private readonly TriviaGames _triviaGames;
+
         private const int CategoriesPerPage = 4;
 
-        internal TriviaGame(ulong gameMessageId, ulong playerId, string category = "any",
+        internal TriviaGame(ulong gameMessageId, ulong playerId, TriviaGames triviaGames, string category = "any",
             string difficulty = "", string questionType = "")
         {
+            _triviaGames = triviaGames;
             PlayerId = playerId;
             GameMessageId = gameMessageId;
             Difficulty = difficulty;
             QuestionType = questionType;
             previousQuestions = new List<Question>();
-            Category = TriviaGames.Categories.Find(cat => cat.name.ToLower() == category);
-            _token = TriviaGames.NewToken().Result;
+            Category = _triviaGames.Categories.Find(cat => cat.name.ToLower() == category);
+            _token = _triviaGames.NewToken().Result;
             _currentCategoryPage = 1;
             _gamestate = GameStates.StartPage;
-            _emb = TriviaGames.TrivaStartingEmbed(this);
+            _emb = _triviaGames.TrivaStartingEmbed(this);
         }
 
         // Main function that gets triggered when a player reacts to their gamemessage
@@ -87,7 +90,7 @@ namespace CommunityBot.Features.Trivia
         private void PrepareStartMenue(IUserMessage socketMsg)
         {
             // Get the startmenu embedbuilder that has all the settings of this game set up
-            _emb = TriviaGames.TrivaStartingEmbed(this);
+            _emb = _triviaGames.TrivaStartingEmbed(this);
             // String to build up the stats
             var stats = "";
             // Group the questions by difficulty for stats
@@ -108,7 +111,7 @@ namespace CommunityBot.Features.Trivia
 
                 overallCorrect += correct;
                 overallWrong += wrong;
-                stats += $"{TriviaGames.Difficulties[difficulty.Key]}: " +
+                stats += $"{_triviaGames.Difficulties[difficulty.Key]}: " +
                          $"**{(int)(correct / (correct + wrong) * 100)}%** correct ({correct}/{correct + wrong})\n";
             }
             // Only show the overall stat if the player had questions with different difficulties
@@ -128,21 +131,21 @@ namespace CommunityBot.Features.Trivia
         /// <param name="reaction"></param>
         private void HandleSelectCategoryInput(IUserMessage socketMsg, IReaction reaction)
         {
-            if (reaction.Emote.Equals(TriviaGames.ReactOptions["ok"]))
+            if (reaction.Emote.Equals(_triviaGames.ReactOptions["ok"]))
             {
                 _gamestate = GameStates.StartPage;
                 PrepareStartMenue(socketMsg);
                 return;
             }
-            if (reaction.Emote.Equals(TriviaGames.ReactOptions["left"]))
+            if (reaction.Emote.Equals(_triviaGames.ReactOptions["left"]))
             {
                 _currentCategoryPage = Math.Max(_currentCategoryPage - 1, 1);
                 PrepareCategoryEmb();
                 return;
             }
-            if (reaction.Emote.Equals(TriviaGames.ReactOptions["right"]))
+            if (reaction.Emote.Equals(_triviaGames.ReactOptions["right"]))
             {
-                _currentCategoryPage = Math.Min(_currentCategoryPage + 1, 1 + TriviaGames.Categories.Count / CategoriesPerPage);
+                _currentCategoryPage = Math.Min(_currentCategoryPage + 1, 1 + _triviaGames.Categories.Count / CategoriesPerPage);
                 PrepareCategoryEmb();
                 return;
             }
@@ -168,7 +171,7 @@ namespace CommunityBot.Features.Trivia
                 // If no reaction fits use the "Any" category
                 ? new Category{name = "Any", id = "" }
                 // Else slice out the reaction and trailing / leading whitespaces off the fields value to get the category
-                : TriviaGames.Categories.FirstOrDefault(value => 
+                : _triviaGames.Categories.FirstOrDefault(value => 
                         value.name == enumerable.ToArray()[0].Replace(reaction.Emote.Name, ""
                     ).Trim());
         }
@@ -180,32 +183,32 @@ namespace CommunityBot.Features.Trivia
         {
             var reactionName = reaction.Emote.Name;
             // If the player wants to change the category
-            if (reactionName == TriviaGames.ReactOptions["1"].Name)
+            if (reactionName == _triviaGames.ReactOptions["1"].Name)
             { 
-                socketMsg.AddReactionAsync(TriviaGames.ReactOptions["left"]);
-                socketMsg.AddReactionAsync(TriviaGames.ReactOptions["right"]);
+                socketMsg.AddReactionAsync(_triviaGames.ReactOptions["left"]);
+                socketMsg.AddReactionAsync(_triviaGames.ReactOptions["right"]);
                 PrepareCategoryEmb();
                 _gamestate = GameStates.ChangingCategory;
                 return;
             }
             // If the player wants to change the questiontype
-            if (reactionName == TriviaGames.ReactOptions["2"].Name)
+            if (reactionName == _triviaGames.ReactOptions["2"].Name)
             {
                 // Take the current type and use set it to the next one
-                var index = TriviaGames.QuestionTypes.ToList().FindIndex(q => QuestionType == q.Key);
-                QuestionType = TriviaGames.QuestionTypes.ToList()[(index + 1) % TriviaGames.QuestionTypes.Count].Key;
+                var index = _triviaGames.QuestionTypes.ToList().FindIndex(q => QuestionType == q.Key);
+                QuestionType = _triviaGames.QuestionTypes.ToList()[(index + 1) % _triviaGames.QuestionTypes.Count].Key;
                 PrepareStartMenue(socketMsg);
             }
             // If the player wants to change the difficulty
-            else if (reactionName == TriviaGames.ReactOptions["3"].Name)
+            else if (reactionName == _triviaGames.ReactOptions["3"].Name)
             {
                 // Take the current difficulty and use set it to the next one
-                var index = TriviaGames.Difficulties.ToList().FindIndex(q => Difficulty == q.Key);
-                Difficulty = TriviaGames.Difficulties.ToList()[(index + 1) % TriviaGames.Difficulties.Count].Key;
+                var index = _triviaGames.Difficulties.ToList().FindIndex(q => Difficulty == q.Key);
+                Difficulty = _triviaGames.Difficulties.ToList()[(index + 1) % _triviaGames.Difficulties.Count].Key;
                 PrepareStartMenue(socketMsg);
             }
             // If the player wants to start the game
-            if (reactionName == TriviaGames.ReactOptions["ok"].Name)
+            if (reactionName == _triviaGames.ReactOptions["ok"].Name)
                 await PreparePlayEmb(socketMsg, reaction);
         }
 
@@ -217,12 +220,12 @@ namespace CommunityBot.Features.Trivia
             _emb.Fields.Clear();
             _emb.WithDescription(
                 "Choose the category the questions should be in with the corresponding reaction.\n" +
-                $"You can navigate the pages with {TriviaGames.ReactOptions["left"]} and {TriviaGames.ReactOptions["right"]} "+
-                $"or {TriviaGames.ReactOptions["ok"]} to go back without changing the category.");
-            var categories = TriviaGames.CategoriesPaged(_currentCategoryPage, CategoriesPerPage);
+                $"You can navigate the pages with {_triviaGames.ReactOptions["left"]} and {_triviaGames.ReactOptions["right"]} "+
+                $"or {_triviaGames.ReactOptions["ok"]} to go back without changing the category.");
+            var categories = _triviaGames.CategoriesPaged(_currentCategoryPage, CategoriesPerPage);
             for (var i = 1; i <= categories.Count; i++)
             {
-                _emb.AddField(TriviaGames.ReactOptions[i.ToString()].Name + "  " + categories[i-1].name, Constants.InvisibleString);
+                _emb.AddField(_triviaGames.ReactOptions[i.ToString()].Name + "  " + categories[i-1].name, Constants.InvisibleString);
             }
         }
 
@@ -231,7 +234,7 @@ namespace CommunityBot.Features.Trivia
         /// </summary>
         private async Task HandlePlayingInput(IUserMessage socketMsg, IReaction reaction)
         {
-            if (reaction.Emote.Equals(TriviaGames.ReactOptions["ok"]) && _gamestate == GameStates.Playing)
+            if (reaction.Emote.Equals(_triviaGames.ReactOptions["ok"]) && _gamestate == GameStates.Playing)
             {
                 PrepareStartMenue(socketMsg);
                 _gamestate = GameStates.StartPage;
@@ -254,10 +257,10 @@ namespace CommunityBot.Features.Trivia
             await NewQuestion();
             // Set the gamestate in case we are came from the main menue
             _gamestate = GameStates.Playing;
-            _emb = TriviaGames.QuestionToEmbed(_currentQuestion, _emb);
+            _emb = _triviaGames.QuestionToEmbed(_currentQuestion, _emb);
             // Add empty field for cosmetics and one that tells how to get back to the main menue
             _emb.AddField(Constants.InvisibleString, $"{wrongRightMessage}{Constants.InvisibleString}");
-            _emb.AddField(Constants.InvisibleString, $"{TriviaGames.ReactOptions["ok"]} to get back to the main menue");
+            _emb.AddField(Constants.InvisibleString, $"{_triviaGames.ReactOptions["ok"]} to get back to the main menue");
         }
 
         /// <summary>
@@ -268,7 +271,7 @@ namespace CommunityBot.Features.Trivia
             if (_gamestate == GameStates.Playing)
                 previousQuestions.Add(_currentQuestion);
             _currentQuestion = 
-               (await TriviaGames.GetQuestions(
+               (await _triviaGames.GetQuestions(
                     categoryId: Category.id, difficulty: Difficulty, token: _token, type: QuestionType))
                 .FirstOrDefault();
         }

--- a/CommunityBot/Global.cs
+++ b/CommunityBot/Global.cs
@@ -21,7 +21,6 @@ namespace CommunityBot
     {
         internal static DiscordSocketClient Client { get; set; }
         internal static Dictionary<ulong, string> MessagesIdToTrack { get; set; }
-        internal static List<TriviaGame> TriviaGames { get; set; } = new List<TriviaGame>();
         internal static Random Rng { get; set; } = new Random();
         internal static Slot Slot = new Slot();
         internal static RepeatedTaskHandler TaskHander = new RepeatedTaskHandler();

--- a/CommunityBot/Handlers/DiscordEventHandler.cs
+++ b/CommunityBot/Handlers/DiscordEventHandler.cs
@@ -23,14 +23,16 @@ namespace CommunityBot.Handlers
         private readonly ApplicationSettings _applicationSettings;
         private readonly ServerActivityLogger.ServerActivityLogger _serverActivityLogger;
         private readonly Logger _logger;
+        private readonly TriviaGames _triviaGames;
 
-        public DiscordEventHandler(Logger logger, DiscordSocketClient client, CommandHandler commandHandler, ApplicationSettings applicationSettings,  ServerActivityLogger.ServerActivityLogger serverActivityLogger)
+        public DiscordEventHandler(Logger logger, TriviaGames triviaGames, DiscordSocketClient client, CommandHandler commandHandler, ApplicationSettings applicationSettings,  ServerActivityLogger.ServerActivityLogger serverActivityLogger)
         {
             _logger = logger;
             _client = client;
             _commandHandler = commandHandler;
             _applicationSettings = applicationSettings;
             _serverActivityLogger = serverActivityLogger;
+            _triviaGames = triviaGames;
         }
 
         public void InitDiscordEvents()
@@ -189,7 +191,7 @@ namespace CommunityBot.Handlers
         private async Task ReactionAdded(Cacheable<IUserMessage, ulong> cacheMessage, ISocketMessageChannel channel, SocketReaction reaction)
         {
             if (reaction.User.Value.IsBot) return;
-            TriviaGames.HandleReactionAdded(cacheMessage, reaction);
+            _triviaGames.HandleReactionAdded(cacheMessage, reaction);
             BlogHandler.ReactionAdded(reaction);
         }
 

--- a/CommunityBot/Modules/Admin.cs
+++ b/CommunityBot/Modules/Admin.cs
@@ -25,29 +25,29 @@ namespace CommunityBot.Modules
         [RequireUserPermission(GuildPermission.ManageMessages)]
         public async Task Clear(int amountOfMessagesToDelete)
         {
-            // TODO: Port to Discord .NET 2.0
-            //await Context.Message.Channel.DeleteMessagesAsync(await Context.Message.Channel.GetMessagesAsync(amountOfMessagesToDelete).Flatten());
+            await (Context.Message.Channel as SocketTextChannel).DeleteMessagesAsync(await Context.Message.Channel.GetMessagesAsync(amountOfMessagesToDelete+1).FlattenAsync());
         }
 
         [Command("purge")]
-        [Remarks("Purges A User's Last 100 Messages")]
+        [Remarks("Purges A User's Last Messages. Default Amount To Purge Is 100")]
         [RequireUserPermission(GuildPermission.ManageMessages)]
-        public async Task Clear(SocketGuildUser user)
+        public async Task Clear(SocketGuildUser user, int amountOfMessagesToDelete = 100)
         {
-            // TODO: Port to Discord .NET 2.0
+            if (user == Context.User)
+                amountOfMessagesToDelete++; //Because it will count the purge command as a message
 
-            //var messages = await Context.Message.Channel.GetMessagesAsync(100).Flatten();
+            var messages = await Context.Message.Channel.GetMessagesAsync(amountOfMessagesToDelete).FlattenAsync();
 
-            //var result = messages.Where(x => x.Author.Id == user.Id && x.CreatedAt >= DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(14)));
-
-            //await Context.Message.Channel.DeleteMessagesAsync(result);
+            var result = messages.Where(x => x.Author.Id == user.Id && x.CreatedAt >= DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(14)));
+            
+            await (Context.Message.Channel as SocketTextChannel).DeleteMessagesAsync(result);
 
         }
 
         [Command("kick")]
         [Remarks("Kick A User")]
         [RequireUserPermission(GuildPermission.KickMembers)]
-        public async Task Kick([NoSelf] SocketGuildUser user)
+        public async Task Kick([NoSelf][RequireBotHigherHirachy] SocketGuildUser user)
         {
             await user.KickAsync();
         }
@@ -78,7 +78,7 @@ namespace CommunityBot.Modules
         [Command("ban")]
         [Remarks("Ban A User")]
         [RequireUserPermission(GuildPermission.BanMembers)]
-        public async Task Ban([NoSelf] SocketGuildUser user)
+        public async Task Ban([NoSelf][RequireBotHigherHirachy] SocketGuildUser user)
         {
             await Context.Guild.AddBanAsync(user);
         }

--- a/CommunityBot/Modules/Fun/Trivia.cs
+++ b/CommunityBot/Modules/Fun/Trivia.cs
@@ -12,16 +12,18 @@ namespace CommunityBot.Modules.Fun
 {
     public class Trivia : ModuleBase<SocketCommandContext>
     {
-        [Command("Trivia")]
+        private readonly TriviaGames _triviaGames;
+
+        Trivia(TriviaGames triviaGames)
+        {
+            _triviaGames = triviaGames;
+        }
+
+        [Command("Trivia", RunMode = RunMode.Async)]
         public async Task NewTrivia()
         {
-            var msg = await Context.Channel.SendMessageAsync("", false, TriviaGames.TrivaStartingEmbed().Build());
-            Global.TriviaGames.Add(new TriviaGame(msg.Id, Context.User.Id));
-            await msg.AddReactionAsync(TriviaGames.ReactOptions["1"]);
-            await msg.AddReactionAsync(TriviaGames.ReactOptions["2"]);
-            await msg.AddReactionAsync(TriviaGames.ReactOptions["3"]);
-            await msg.AddReactionAsync(TriviaGames.ReactOptions["4"]);
-            await msg.AddReactionAsync(TriviaGames.ReactOptions["ok"]);
+            var msg = await Context.Channel.SendMessageAsync("", false, _triviaGames.TrivaStartingEmbed().Build());
+            _triviaGames.NewTrivia(msg, Context.User);
         }                                       
     }
 }

--- a/CommunityBot/Preconditions/RequireBotHigherHirachy.cs
+++ b/CommunityBot/Preconditions/RequireBotHigherHirachy.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+
+namespace CommunityBot.Preconditions
+{
+    public class RequireBotHigherHirachy : ParameterPreconditionAttribute
+    {
+        public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, ParameterInfo parameter, object value, IServiceProvider services)
+        {
+            var user = value is SocketGuildUser ? (SocketGuildUser)value : null;
+            
+            var bot = (context.Guild as SocketGuild).GetUser(context.Client.CurrentUser.Id);
+            if ((user != null) && (bot.Hierarchy < user.Hierarchy))
+                return Task.FromResult(PreconditionResult.FromError("I don't have enough permissions"));
+
+            return Task.FromResult(PreconditionResult.FromSuccess());
+        }
+    }
+}

--- a/CommunityBot/Program.cs
+++ b/CommunityBot/Program.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Discord;
 using CommunityBot.Configuration;
+using CommunityBot.Features.Trivia;
 using CommunityBot.Handlers;
 using Microsoft.Extensions.DependencyInjection;
 using Discord.Commands;
@@ -101,6 +102,7 @@ namespace CommunityBot
                 .AddSingleton<CommandHandler>()
                 .AddSingleton<DiscordEventHandler>()
                 .AddSingleton<Logger>()
+                .AddSingleton<TriviaGames>()
                 .BuildServiceProvider();     
         }
     }


### PR DESCRIPTION
**New attribute precondition**  RequireBotHigherHirachy : Checks if the bot got a higher Hirachy than a SocketGuildUser used as parameter.

**Admin module changes:**
- Purge command ported to Discord.NET 2.0
- The purge command with SocketGuildUser as first parameter, insted of deleting a fixed amount of messages, now allows a second optional parameter to indicate the amount of messages to delete, with 100 as default value. **Not working propely, because gets the last 100 messages, and they're not always from the same author**
- Kick and ban commands SocketGuildUser parameter now got the attribute precondition _RequireBotHigherHirachy_. This will avoid the bot to send a message with an error 403, will send a more user-friendly message.

**Trivia changes**
- TriviaGames is now a service, with injected dependencies #69 
I'm not sure at all if this is the right way to do it, TriviaGame is still attached to TriviaGames, added TriviaGames parameter in the constructor
`internal TriviaGame(ulong gameMessageId, ulong playerId, TriviaGames triviaGames, string category = "any", string difficulty = "", string questionType = "")`
Would be good to store the active trivia games a certain amount of time (1 week?) so if the bot is restarted, can still work with pre-restart messages. 
Also an option to completly end the game, for example, a ❌ reaction would remove the game from the activeTriviaGames array, and edit the message with the stats the user had in that game.