### PR TITLE
Make Constant arrays Immutable - Fixes #76

### DIFF
--- a/CommunityBot.Tests/ImmutableConstantsTests.cs
+++ b/CommunityBot.Tests/ImmutableConstantsTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace CommunityBot.Tests
 {
-    public class ImmutableConstantsTests
+    public static class ImmutableConstantsTests
     {
         [Fact]
         public static void ConstantArrayIsImmutableTest()

--- a/CommunityBot.Tests/ImmutableConstantsTests.cs
+++ b/CommunityBot.Tests/ImmutableConstantsTests.cs
@@ -1,0 +1,17 @@
+using System;
+using Xunit;
+
+namespace CommunityBot.Tests
+{
+    public class ImmutableConstantsTests
+    {
+        [Fact]
+        public void ConstantArrayIsImmutableTest()
+        {
+            Assert.Throws<NotSupportedException>(() => Constants.DidYouKnows.Add("Hello, World!"));
+            Assert.Throws<NotSupportedException>(() => Constants.DidYouKnows.RemoveAt(0));
+            Assert.Throws<NotSupportedException>(() => Constants.DidYouKnows[0] = "Hello, World!");
+            Assert.Throws<NotSupportedException>(() => Constants.DidYouKnows.Clear());
+        }
+    }
+}

--- a/CommunityBot.Tests/ImmutableConstantsTests.cs
+++ b/CommunityBot.Tests/ImmutableConstantsTests.cs
@@ -6,7 +6,7 @@ namespace CommunityBot.Tests
     public class ImmutableConstantsTests
     {
         [Fact]
-        public void ConstantArrayIsImmutableTest()
+        public static void ConstantArrayIsImmutableTest()
         {
             Assert.Throws<NotSupportedException>(() => Constants.DidYouKnows.Add("Hello, World!"));
             Assert.Throws<NotSupportedException>(() => Constants.DidYouKnows.RemoveAt(0));

--- a/CommunityBot/Constants.cs
+++ b/CommunityBot/Constants.cs
@@ -20,7 +20,7 @@ namespace CommunityBot
         public static readonly Tuple<int, int> MessagRewardMinMax = Tuple.Create(1, 5);
         public static readonly int MinTimerIntervall = 3000;
 
-        public static readonly string[] DidYouKnows = {
+        public static readonly IList<string> DidYouKnows = new List<string> {
             "You can fork me on GitHub ;) xoxo <3",
             "If you don't know what to add, you can add some of my messages. :P",
             "Wanna see someone's Miunies? Add a mention to your cash command.",
@@ -28,6 +28,6 @@ namespace CommunityBot
             "Protection? I don't accept code just from anybody, alright?",
             "You get a couple Miunies for sending messages (with a short cooldown).", 
             "A lot of commands have shorter and easier to use aliases!"
-        };
+        }.AsReadOnly();
     }
 }

--- a/CommunityBot/Global.cs
+++ b/CommunityBot/Global.cs
@@ -24,7 +24,7 @@ namespace CommunityBot
 
         internal static string GetRandomDidYouKnow()
         {
-            return Constants.DidYouKnows[Rng.Next(0, Constants.DidYouKnows.Length)];
+            return Constants.DidYouKnows[Rng.Next(0, Constants.DidYouKnows.Count)];
         }
         
         public static string ReplacePlacehoderStrings(this string messageString, IGuildUser user = null)


### PR DESCRIPTION
Constant array in the `Constants` class were not really constant. They were mutable and that not intended.